### PR TITLE
Allow git installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installation
 ----------------
 Run this command in the graphical CLI:
 <pre>
-svn checkout https://github.com/Ezandora/Latte/trunk/Release/
+git checkout Ezandora/Latte
 </pre>
 And restart mafia.
 Will require [a recent build of KoLMafia](http://builds.kolmafia.us/job/Kolmafia/lastSuccessfulBuild/).

--- a/Release/dependencies.txt
+++ b/Release/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Choice-Override/branches/Release/
+github Ezandora/Choice-Override Release

--- a/Release/relay/choice.1329.ash
+++ b/Release/relay/choice.1329.ash
@@ -118,11 +118,14 @@ location [string] __locations_for_ingredients =
 	"cloves":$location[The Sleazy Back Alley],
 	"coal":$location[The Haunted Boiler Room],
 	"cocoa powder":$location[The Icy Peak],
+	"diet soda":$location[Battlefield (No Uniform)],
 	"dwarf cream":$location[Itznotyerzitz Mine],
+	"Dyspepsi":$location[Battlefield (Dyspepsi Uniform)],
 	"filth milk":$location[The Feeding Chamber],
 	"fresh grass":$location[The Hidden Park],
 	"fungus":$location[The Fungal Nethers],
 	"grave mold":$location[the unquiet garves],
+	"greek spice":$location[Wartime Frat House],
 	"grobold rum":$location[The Old Rubee Mine],
 	"guarna":$location[The Bat Hole Entrance],
 	"gunpowder":$location[1st Floor\, Shiawase-Mitsuhama Building],
@@ -132,6 +135,7 @@ location [string] __locations_for_ingredients =
 	"hot sausage":$location[Cobb's Knob Barracks], //'
 	"hot wing":$location[The Dark Heart of the Woods],
 	"ink":$location[The Haunted Library],
+	"kombucha":$location[Wartime Hippy Camp],
 	"lihc saliva":$location[The Defiled Niche],
 	"lizard milk":$location[The Arid\, Extra-Dry Desert],
 	"macaroni":$location[The Haunted Pantry],
@@ -148,18 +152,12 @@ location [string] __locations_for_ingredients =
 	"sandalwood splinter":$location[Noob Cave],
 	"sausage":$location[Cobb's Knob Kitchens], //'
 	"space pumpkin":$location[The Hole in the Sky],
+	"spaghetti squash spice":$location[The Copperhead Club],
 	"squamous":$location[The Caliginous Abyss],
 	"teeth":$location[The VERY Unquiet Garves],
 	"vanilla":$location[none],
 	"vitamin":$location[The Dark Elbow of the Woods],
 	"white flour":$location[The Road to the White Citadel],
-	"spaghetti squash spice":$location[The Copperhead Club],
-	"diet soda":$location[Battlefield (No Uniform)],
-	"greek spice":$location[Wartime Frat House],
-	"kombucha":$location[Wartime Hippy Camp],
-	
-	/*
-	"Dyspepsi":$location[REPLACEME],*/
 };
 
 int INGREDIENT_GROUPING_USEFUL = 1;

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,3 @@
+{
+   "root_directory": "Release"
+}


### PR DESCRIPTION
github is removing SVN support on Jan 8, 2024
KoLmafia can install scripts via GIT.

1) If you do not have a branch with your code, manifest.json tells KoLmafia where the root of the code is.
2) dependencies.txt can have "github" syntax which will look for either SVN or GIT installation and will install via GIT if not yet installed.
